### PR TITLE
Pass through whisper-rs backend selection features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,10 @@ stts_connection_handler = { path = "stts_connection_handler" }
 default = ["simd"]
 
 cuda = ["stts_speech_to_text/cuda"]
+opencl = ["stts_speech_to_text/opencl"]
 simd = ["stts_speech_to_text/simd"]
 
 # These additional backends have not been tested
 coreml = ["stts_speech_to_text/coreml"]
 metal = ["stts_speech_to_text/metal"]
 openblas = ["stts_speech_to_text/openblas"]
-opencl = ["stts_speech_to_text/opencl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,15 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 stts_speech_to_text = { path = "stts_speech_to_text" }
 stts_connection_handler = { path = "stts_connection_handler" }
+
+[features]
+default = ["simd"]
+
+cuda = ["stts_speech_to_text/cuda"]
+simd = ["stts_speech_to_text/simd"]
+
+# These additional backends have not been tested
+coreml = ["stts_speech_to_text/coreml"]
+metal = ["stts_speech_to_text/metal"]
+openblas = ["stts_speech_to_text/openblas"]
+opencl = ["stts_speech_to_text/opencl"]

--- a/stts_speech_to_text/Cargo.toml
+++ b/stts_speech_to_text/Cargo.toml
@@ -9,4 +9,12 @@ edition = "2021"
 tracing = "0.1"
 once_cell = "1"
 tokio = { version = "1", features = ["full"] }
-whisper-rs = { git = "https://github.com/tazz4843/whisper-rs", features = ["simd"] }
+whisper-rs = { git = "https://github.com/tazz4843/whisper-rs" }
+
+[features]
+coreml = ["whisper-rs/coreml"]
+cuda = ["whisper-rs/cuda"]
+metal = ["whisper-rs/metal"]
+openblas = ["whisper-rs/openblas"]
+opencl = ["whisper-rs/opencl"]
+simd = ["whisper-rs/simd"]


### PR DESCRIPTION
This PR exposes `whisper-rs` backend selection features to the top level app, to make it easy to choose which backend to run stt-service on without editing Cargo.toml. It also makes it possible to turn off simd, in case someone ever wants to do that.